### PR TITLE
Implement Postgres kid migrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+*.iml
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:17-jdk-slim AS build
+WORKDIR /app
+COPY pom.xml .
+RUN mvn -B -e -q -DskipTests package dependency:go-offline
+COPY src src
+RUN mvn -B -e -q -DskipTests package
+
+FROM openjdk:17-jre-slim
+WORKDIR /app
+COPY --from=build /app/target/kid-migrator-1.0-SNAPSHOT.jar app.jar
+COPY src/main/resources/config.properties config.properties
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/deployment.yml
+++ b/deployment.yml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kid-migrator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kid-migrator
+  template:
+    metadata:
+      labels:
+        app: kid-migrator
+    spec:
+      containers:
+        - name: kid-migrator
+          image: kid-migrator:latest
+          env:
+            - name: SOURCE_URL
+              value: jdbc:postgresql://source-db:5432/source
+            - name: SOURCE_USER
+              value: source_user
+            - name: SOURCE_PASSWORD
+              value: source_pass
+            - name: TARGET_URL
+              value: jdbc:postgresql://target-db:5432/target
+            - name: TARGET_USER
+              value: target_user
+            - name: TARGET_PASSWORD
+              value: target_pass
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.properties
+              subPath: config.properties
+      volumes:
+        - name: config
+          configMap:
+            name: kid-migrator-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kid-migrator-config
+data:
+  config.properties: |
+    source.url=${SOURCE_URL}
+    source.user=${SOURCE_USER}
+    source.password=${SOURCE_PASSWORD}
+    target.url=${TARGET_URL}
+    target.user=${TARGET_USER}
+    target.password=${TARGET_PASSWORD}
+    batchSize=1000
+    taskName=default-task

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>kid-migrator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/example/migrator/Config.java
+++ b/src/main/java/com/example/migrator/Config.java
@@ -1,0 +1,41 @@
+package com.example.migrator;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public record Config(
+        String sourceUrl,
+        String sourceUser,
+        String sourcePassword,
+        String targetUrl,
+        String targetUser,
+        String targetPassword,
+        int batchSize,
+        String taskName,
+        List<String> ids) {
+
+    public static Config from(Properties props) {
+        String idsFile = props.getProperty("idsFile");
+        List<String> ids = null;
+        if (idsFile != null) {
+            try (var reader = new java.io.BufferedReader(new java.io.FileReader(idsFile))) {
+                ids = reader.lines().filter(s -> !s.isBlank()).collect(Collectors.toList());
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to read ids file", e);
+            }
+        }
+        return new Config(
+                props.getProperty("source.url"),
+                props.getProperty("source.user"),
+                props.getProperty("source.password"),
+                props.getProperty("target.url"),
+                props.getProperty("target.user"),
+                props.getProperty("target.password"),
+                Integer.parseInt(props.getProperty("batchSize", "1000")),
+                props.getProperty("taskName", "default"),
+                ids
+        );
+    }
+}

--- a/src/main/java/com/example/migrator/MigrationApp.java
+++ b/src/main/java/com/example/migrator/MigrationApp.java
@@ -1,0 +1,22 @@
+package com.example.migrator;
+
+import java.io.*;
+import java.sql.*;
+import java.util.*;
+
+public class MigrationApp {
+    public static void main(String[] args) throws Exception {
+        Properties props = new Properties();
+        try (InputStream in = MigrationApp.class.getClassLoader().getResourceAsStream("config.properties")) {
+            if (in == null) {
+                System.err.println("config.properties not found");
+                return;
+            }
+            props.load(in);
+        }
+
+        Config config = Config.from(props);
+        MigrationService service = new MigrationService(config);
+        service.run();
+    }
+}

--- a/src/main/java/com/example/migrator/MigrationService.java
+++ b/src/main/java/com/example/migrator/MigrationService.java
@@ -1,0 +1,124 @@
+package com.example.migrator;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.postgresql.PGConnection;
+import org.postgresql.copy.CopyManager;
+
+import java.io.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MigrationService {
+    private final Config config;
+
+    public MigrationService(Config config) {
+        this.config = config;
+    }
+
+    public void run() throws Exception {
+        try (Connection src = DriverManager.getConnection(config.sourceUrl(), config.sourceUser(), config.sourcePassword());
+             Connection dst = DriverManager.getConnection(config.targetUrl(), config.targetUser(), config.targetPassword())) {
+
+            ensureProgressTable(dst);
+            String lastId = loadProgress(dst, config.taskName());
+            List<String> ids = config.ids();
+            if (ids == null) {
+                // load ids from source if no file provided
+                ids = fetchIds(src, lastId);
+            } else if (lastId != null) {
+                ids = ids.subList(ids.indexOf(lastId) + 1, ids.size());
+            }
+
+            processIds(src, dst, ids);
+        }
+    }
+
+    private List<String> fetchIds(Connection src, String lastId) throws Exception {
+        List<String> ids = new ArrayList<>();
+        String query = "SELECT id FROM person WHERE birthDay > current_date - interval '18 years'" +
+                (lastId != null ? " AND id > '" + lastId + "'" : "") +
+                " ORDER BY id";
+        try (Statement st = src.createStatement(); ResultSet rs = st.executeQuery(query)) {
+            while (rs.next()) {
+                ids.add(rs.getString(1));
+            }
+        }
+        return ids;
+    }
+
+    private void processIds(Connection src, Connection dst, List<String> ids) throws Exception {
+        if (ids.isEmpty()) {
+            return;
+        }
+        CopyManager srcCopy = src.unwrap(PGConnection.class).getCopyAPI();
+        CopyManager dstCopy = dst.unwrap(PGConnection.class).getCopyAPI();
+
+        int batchSize = config.batchSize();
+        List<String> batch = new ArrayList<>(batchSize);
+        for (String id : ids) {
+            batch.add(id);
+            if (batch.size() >= batchSize) {
+                copyBatch(srcCopy, dstCopy, dst, batch);
+                saveProgress(dst, config.taskName(), batch.get(batch.size() - 1));
+                batch.clear();
+            }
+        }
+        if (!batch.isEmpty()) {
+            copyBatch(srcCopy, dstCopy, dst, batch);
+            saveProgress(dst, config.taskName(), batch.get(batch.size() - 1));
+        }
+    }
+
+    private void copyBatch(CopyManager srcCopy, CopyManager dstCopy, Connection dst, List<String> batch) throws Exception {
+        String inList = batch.stream().map(id -> "'" + id + "'").reduce((a,b) -> a + "," + b).orElse("'0'");
+        String copyOutSql = "COPY (SELECT id, birthday FROM person WHERE id IN (" + inList + ")) TO STDOUT WITH (FORMAT CSV)";
+        String copyInSql = "COPY kids (id, birthday) FROM STDIN WITH (FORMAT CSV)";
+        try (var reader = new InputStreamReader(srcCopy.copyOut(copyOutSql));
+             var writer = new StringWriter();
+             CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
+            new BufferedReader(reader).lines().forEach(line -> {
+                try {
+                    printer.printRecord(line.split(",", 2));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            printer.flush();
+            byte[] data = writer.toString().getBytes();
+            dst.setAutoCommit(false);
+            dstCopy.copyIn(copyInSql, new ByteArrayInputStream(data));
+            dst.commit();
+        }
+    }
+
+    private void ensureProgressTable(Connection dst) throws Exception {
+        try (Statement st = dst.createStatement()) {
+            st.executeUpdate("CREATE TABLE IF NOT EXISTS migration_progress (task_name text primary key, last_id text)");
+        }
+    }
+
+    private String loadProgress(Connection dst, String task) throws Exception {
+        try (Statement st = dst.createStatement(); ResultSet rs = st.executeQuery("SELECT last_id FROM migration_progress WHERE task_name='" + task + "'")) {
+            if (rs.next()) {
+                return rs.getString(1);
+            }
+        }
+        return null;
+    }
+
+    private void saveProgress(Connection dst, String task, String lastId) throws Exception {
+        dst.setAutoCommit(false);
+        try (Statement st = dst.createStatement()) {
+            int updated = st.executeUpdate("UPDATE migration_progress SET last_id='" + lastId + "' WHERE task_name='" + task + "'");
+            if (updated == 0) {
+                st.executeUpdate("INSERT INTO migration_progress(task_name, last_id) VALUES('" + task + "', '" + lastId + "')");
+            }
+        }
+        dst.commit();
+    }
+}

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,0 +1,18 @@
+# Source database
+source.url=jdbc:postgresql://source-db:5432/source
+source.user=source_user
+source.password=source_pass
+
+# Target database
+target.url=jdbc:postgresql://target-db:5432/target
+target.user=target_user
+target.password=target_pass
+
+# Batch size for inserts
+batchSize=1000
+
+# Unique name for this migration task
+taskName=default-task
+
+# Optional file with list of IDs to process
+#idsFile=ids.txt


### PR DESCRIPTION
## Summary
- set up Maven project for a simple migration app
- implement `MigrationService` using PostgreSQL COPY to move IDs and birthdays
- save migration progress so the job can resume
- provide Dockerfile and Kubernetes deployment example

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543c54769c8330b04864006df08697