### PR TITLE
Add migration test using embedded Postgres

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
             <version>2.2.224</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.zonky.test.postgres</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <version>2.0.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/example/migrator/MigrationServiceEmbeddedPostgresTest.java
+++ b/src/test/java/com/example/migrator/MigrationServiceEmbeddedPostgresTest.java
@@ -1,0 +1,51 @@
+package com.example.migrator;
+
+import io.zonky.test.postgres.embedded.EmbeddedPostgres;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MigrationServiceEmbeddedPostgresTest {
+
+    @Test
+    void migrationCopiesRows() throws Exception {
+        try (EmbeddedPostgres src = EmbeddedPostgres.builder()
+                .setProvider(EmbeddedPostgres.PreferredProvider.ZONKY)
+                .start();
+             EmbeddedPostgres dst = EmbeddedPostgres.builder()
+                .setProvider(EmbeddedPostgres.PreferredProvider.ZONKY)
+                .start()) {
+
+            String srcUrl = src.getJdbcUrl("postgres", "postgres");
+            String dstUrl = dst.getJdbcUrl("postgres", "postgres");
+
+            try (Connection c = DriverManager.getConnection(srcUrl, "postgres", "postgres");
+                 Statement st = c.createStatement()) {
+                st.execute("CREATE TABLE person(id text primary key, birthday date)");
+                st.execute("INSERT INTO person(id, birthday) VALUES('1', current_date - interval '10 years')");
+                st.execute("INSERT INTO person(id, birthday) VALUES('2', current_date - interval '20 years')");
+                st.execute("INSERT INTO person(id, birthday) VALUES('3', current_date - interval '5 years')");
+            }
+            try (Connection c = DriverManager.getConnection(dstUrl, "postgres", "postgres");
+                 Statement st = c.createStatement()) {
+                st.execute("CREATE TABLE kids(id text primary key, birthday date)");
+            }
+
+            Config cfg = new Config(srcUrl, "postgres", "postgres", dstUrl, "postgres", "postgres", 10, "task", null);
+            MigrationService service = new MigrationService(cfg);
+            service.run();
+
+            try (Connection c = DriverManager.getConnection(dstUrl, "postgres", "postgres");
+                 Statement st = c.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT count(*) FROM kids")) {
+                assertTrue(rs.next());
+                assertEquals(2, rs.getInt(1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `embedded-postgres` test dependency
- implement integration test using Zonky embedded Postgres provider

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68552cab913c8330acdd852d5254bee2