### PR TITLE
Add logging and metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,21 @@
             <artifactId>commons-csv</artifactId>
             <version>1.10.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.16.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>0.16.0</version>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/example/migrator/MigrationApp.java
+++ b/src/main/java/com/example/migrator/MigrationApp.java
@@ -1,5 +1,6 @@
 package com.example.migrator;
 
+import io.prometheus.client.exporter.HTTPServer;
 import java.io.*;
 import java.sql.*;
 import java.util.*;
@@ -17,6 +18,11 @@ public class MigrationApp {
 
         Config config = Config.from(props);
         MigrationService service = new MigrationService(config);
-        service.run();
+        HTTPServer server = new HTTPServer(9090);
+        try {
+            service.run();
+        } finally {
+            server.close();
+        }
     }
 }

--- a/src/main/java/com/example/migrator/MigrationService.java
+++ b/src/main/java/com/example/migrator/MigrationService.java
@@ -4,6 +4,10 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.postgresql.PGConnection;
 import org.postgresql.copy.CopyManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 
 import java.io.*;
 import java.sql.Connection;
@@ -14,6 +18,23 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MigrationService {
+    private static final Logger log = LoggerFactory.getLogger(MigrationService.class);
+
+    static final Counter processedCounter = Counter.build()
+            .name("migrator_processed_total")
+            .help("Total processed records")
+            .register();
+
+    static final Counter errorCounter = Counter.build()
+            .name("migrator_errors_total")
+            .help("Total errors during migration")
+            .register();
+
+    static final Gauge speedGauge = Gauge.build()
+            .name("migrator_speed")
+            .help("Average records per second")
+            .register();
+
     private final Config config;
 
     public MigrationService(Config config) {
@@ -21,21 +42,29 @@ public class MigrationService {
     }
 
     public void run() throws Exception {
+        log.info("Starting migration task {}", config.taskName());
+        long start = System.nanoTime();
         try (Connection src = DriverManager.getConnection(config.sourceUrl(), config.sourceUser(), config.sourcePassword());
              Connection dst = DriverManager.getConnection(config.targetUrl(), config.targetUser(), config.targetPassword())) {
 
+            log.info("Ensuring progress table");
             ensureProgressTable(dst);
+            log.info("Loading last processed id for task {}", config.taskName());
             String lastId = loadProgress(dst, config.taskName());
+            log.info("Last processed id: {}", lastId);
             List<String> ids = config.ids();
             if (ids == null) {
-                // load ids from source if no file provided
+                log.info("Fetching ids from source");
                 ids = fetchIds(src, lastId);
             } else if (lastId != null) {
+                log.info("Resuming from id {}", lastId);
                 ids = ids.subList(ids.indexOf(lastId) + 1, ids.size());
             }
 
-            processIds(src, dst, ids);
+            log.info("Total ids to process: {}", ids.size());
+            processIds(src, dst, ids, start);
         }
+        log.info("Migration finished. Total processed {}", (int)processedCounter.get());
     }
 
     private List<String> fetchIds(Connection src, String lastId) throws Exception {
@@ -43,15 +72,17 @@ public class MigrationService {
         String query = "SELECT id FROM person WHERE birthDay > current_date - interval '18 years'" +
                 (lastId != null ? " AND id > '" + lastId + "'" : "") +
                 " ORDER BY id";
+        log.info("Fetching ids with query: {}", query);
         try (Statement st = src.createStatement(); ResultSet rs = st.executeQuery(query)) {
             while (rs.next()) {
                 ids.add(rs.getString(1));
             }
         }
+        log.info("Fetched {} ids", ids.size());
         return ids;
     }
 
-    private void processIds(Connection src, Connection dst, List<String> ids) throws Exception {
+    private void processIds(Connection src, Connection dst, List<String> ids, long start) throws Exception {
         if (ids.isEmpty()) {
             return;
         }
@@ -60,16 +91,29 @@ public class MigrationService {
 
         int batchSize = config.batchSize();
         List<String> batch = new ArrayList<>(batchSize);
+        int processed = 0;
         for (String id : ids) {
             batch.add(id);
             if (batch.size() >= batchSize) {
                 copyBatch(srcCopy, dstCopy, dst, batch);
+                processedCounter.inc(batch.size());
+                processed += batch.size();
+                double duration = (System.nanoTime() - start) / 1_000_000_000.0;
+                double speed = processed / duration;
+                speedGauge.set(speed);
+                log.info("Processed {} of {} ids ({} recs/sec)", processed, ids.size(), String.format("%.2f", speed));
                 saveProgress(dst, config.taskName(), batch.get(batch.size() - 1));
                 batch.clear();
             }
         }
         if (!batch.isEmpty()) {
             copyBatch(srcCopy, dstCopy, dst, batch);
+            processedCounter.inc(batch.size());
+            processed += batch.size();
+            double duration = (System.nanoTime() - start) / 1_000_000_000.0;
+            double speed = processed / duration;
+            speedGauge.set(speed);
+            log.info("Processed {} of {} ids ({} recs/sec)", processed, ids.size(), String.format("%.2f", speed));
             saveProgress(dst, config.taskName(), batch.get(batch.size() - 1));
         }
     }
@@ -81,6 +125,7 @@ public class MigrationService {
         try (var srcWriter = new StringWriter();
              var writer = new StringWriter();
              CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT)) {
+            log.debug("Copying batch of {} ids", batch.size());
             // Copy data from the source database into a string
             srcCopy.copyOut(copyOutSql, srcWriter);
             // Parse each line and reprint using CSVPrinter to normalise CSV format
@@ -94,18 +139,27 @@ public class MigrationService {
             printer.flush();
             byte[] data = writer.toString().getBytes();
             dst.setAutoCommit(false);
-            dstCopy.copyIn(copyInSql, new ByteArrayInputStream(data));
-            dst.commit();
+            try {
+                dstCopy.copyIn(copyInSql, new ByteArrayInputStream(data));
+                dst.commit();
+            } catch (Exception e) {
+                errorCounter.inc();
+                log.error("Error copying batch", e);
+                dst.rollback();
+                throw e;
+            }
         }
     }
 
     private void ensureProgressTable(Connection dst) throws Exception {
+        log.debug("Ensuring progress table exists");
         try (Statement st = dst.createStatement()) {
             st.executeUpdate("CREATE TABLE IF NOT EXISTS migration_progress (task_name text primary key, last_id text)");
         }
     }
 
     private String loadProgress(Connection dst, String task) throws Exception {
+        log.debug("Loading progress for task {}", task);
         try (Statement st = dst.createStatement(); ResultSet rs = st.executeQuery("SELECT last_id FROM migration_progress WHERE task_name='" + task + "'")) {
             if (rs.next()) {
                 return rs.getString(1);
@@ -115,6 +169,7 @@ public class MigrationService {
     }
 
     private void saveProgress(Connection dst, String task, String lastId) throws Exception {
+        log.debug("Saving progress for task {}: {}", task, lastId);
         dst.setAutoCommit(false);
         try (Statement st = dst.createStatement()) {
             int updated = st.executeUpdate("UPDATE migration_progress SET last_id='" + lastId + "' WHERE task_name='" + task + "'");

--- a/src/test/java/com/example/migrator/MigrationServiceEmbeddedPostgresTest.java
+++ b/src/test/java/com/example/migrator/MigrationServiceEmbeddedPostgresTest.java
@@ -2,6 +2,7 @@ package com.example.migrator;
 
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import org.junit.jupiter.api.Test;
+import io.prometheus.client.CollectorRegistry;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -35,6 +36,8 @@ public class MigrationServiceEmbeddedPostgresTest {
             Config cfg = new Config(srcUrl, "postgres", "postgres", dstUrl, "postgres", "postgres", 10, "task", null);
             MigrationService service = new MigrationService(cfg);
             service.run();
+            Double processed = CollectorRegistry.defaultRegistry.getSampleValue("migrator_processed_total");
+            assertEquals(2.0, processed);
 
             try (Connection c = DriverManager.getConnection(dstUrl, "postgres", "postgres");
                  Statement st = c.createStatement();


### PR DESCRIPTION
## Summary
- add slf4j and prometheus dependencies
- log progress, errors and processing speed in `MigrationService`
- expose Prometheus metrics via `HTTPServer`
- verify metric creation in integration test

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685532063f40833085361ad17f2813ee