### PR TITLE
Fix locale in embedded postgres tests

### DIFF
--- a/src/test/java/com/example/migrator/MigrationServiceEmbeddedPostgresTest.java
+++ b/src/test/java/com/example/migrator/MigrationServiceEmbeddedPostgresTest.java
@@ -13,10 +13,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class MigrationServiceEmbeddedPostgresTest {
 
+    private static final String LOCALE = "C";
+
     @Test
     void migrationCopiesRows() throws Exception {
-        try (EmbeddedPostgres src = EmbeddedPostgres.builder().setLocaleConfig("locale", "en_US.UTF-8").start();
-             EmbeddedPostgres dst = EmbeddedPostgres.builder().setLocaleConfig("locale", "en_US.UTF-8").start()) {
+        try (EmbeddedPostgres src = EmbeddedPostgres.builder().setLocaleConfig("locale", LOCALE).start();
+             EmbeddedPostgres dst = EmbeddedPostgres.builder().setLocaleConfig("locale", LOCALE).start()) {
 
             String srcUrl = src.getJdbcUrl("postgres", "postgres");
             String dstUrl = dst.getJdbcUrl("postgres", "postgres");
@@ -50,8 +52,8 @@ public class MigrationServiceEmbeddedPostgresTest {
 
     @Test
     void migrationCopies1000RowsInChunksOf100() throws Exception {
-        try (EmbeddedPostgres src = EmbeddedPostgres.builder().setLocaleConfig("locale", "C").start();
-             EmbeddedPostgres dst = EmbeddedPostgres.builder().setLocaleConfig("locale", "C").start()) {
+        try (EmbeddedPostgres src = EmbeddedPostgres.builder().setLocaleConfig("locale", LOCALE).start();
+             EmbeddedPostgres dst = EmbeddedPostgres.builder().setLocaleConfig("locale", LOCALE).start()) {
 
             String srcUrl = src.getJdbcUrl("postgres", "postgres");
             String dstUrl = dst.getJdbcUrl("postgres", "postgres");
@@ -83,8 +85,8 @@ public class MigrationServiceEmbeddedPostgresTest {
 
     @Test
     void migrationCopies3000Of10000RowsByAge() throws Exception {
-        try (EmbeddedPostgres src = EmbeddedPostgres.builder().setLocaleConfig("locale", "C").start();
-             EmbeddedPostgres dst = EmbeddedPostgres.builder().setLocaleConfig("locale", "C").start()) {
+        try (EmbeddedPostgres src = EmbeddedPostgres.builder().setLocaleConfig("locale", LOCALE).start();
+             EmbeddedPostgres dst = EmbeddedPostgres.builder().setLocaleConfig("locale", LOCALE).start()) {
 
             String srcUrl = src.getJdbcUrl("postgres", "postgres");
             String dstUrl = dst.getJdbcUrl("postgres", "postgres");


### PR DESCRIPTION
## Summary
- use a constant for the `C` locale in MigrationServiceEmbeddedPostgresTest

## Testing
- `sh mvnw -s settings.xml test >test.log 2>&1 && tail -n 20 test.log`

------
https://chatgpt.com/codex/tasks/task_e_6856734899a083309f8755c537061d76